### PR TITLE
Hotfix for extension display in list item

### DIFF
--- a/ui/src/components/dashboard/audio_list_item.test.coffee
+++ b/ui/src/components/dashboard/audio_list_item.test.coffee
@@ -27,6 +27,20 @@ describe 'audio-list-item', ->
 
     hover_title = 'Open up chicken.mp3 in a new tab'
     expect(title_link.element.getAttribute('title')).to.eql hover_title
+  
+  describe 'when no extension is provided', ->
+    beforeEach ->
+      @wrapper = mount audio_list_item, globals: ($store: @store), propsData:
+        audio: audios_fixture.extensionless
+        q: null
+    
+    it 'should not have an extension displayed', ->
+      expect(@wrapper.find('.extension')).to.have.length 0
+    
+    it 'should have a "no extension" message displayed', ->
+      no_extension = @wrapper.first '.no-extension'
+      expect(@wrapper.find('.no-extension')).to.have.length 1
+      expect(no_extension.text()).to.eql '[no extension]'
 
   it 'should render details', ->
     expect(@wrapper.first('.description').text()).to.eql 'A chick bok-bok'

--- a/ui/src/components/dashboard/audio_list_item.vue
+++ b/ui/src/components/dashboard/audio_list_item.vue
@@ -26,8 +26,9 @@
         )
           .basename
             text-with-search-highlight(:text='basename', :q='q')
-          .extension
+          .extension(v-if='extension')
             text-with-search-highlight(:text='extension', :q='q')
+          .no-extension(v-if='!extension') [no extension]
         span.fa.fa-eye-slash(v-if='!audio.visible')
       .description {{ display_description }}
       ul.meta
@@ -84,8 +85,6 @@
       extension: ->
         if @audio.url.split('.')[1]
           '.' + @audio.url.split('.')[1]
-        else
-          '&nbsp;(no extension)'
     methods:
       handle_edit_clicked: (e) ->
         e.stopPropagation()
@@ -163,11 +162,19 @@
         font-size: 1.5rem;
       }
       .basename,
-      .extension {
+      .extension,
+      .no-extension {
         display: inline-block;
       }
       .extension {
         color: $blue;
+      }
+      .no-extension {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        font-weight: 800;
+        color: $gray-dark;
+        margin-left: 1em;
       }
       .description {
         font-style: italic;

--- a/ui/src/fixtures/audios.coffee
+++ b/ui/src/fixtures/audios.coffee
@@ -21,4 +21,15 @@ export default {
     updateUrl: '/api/audios/2'
     duration: 3
     visible: false
+  extensionless:
+    id: 3
+    url: 'extensionless'
+    createdAt: new Date('2017-07-31T00:00:00.001Z')
+    description: 'What am I in this big big world...'
+    publicUrl: '/extensionless'
+    downloadUrl: '/extensionless/download'
+    editUrl: '/audios/3/edit'
+    updateUrl: '/api/audios/3'
+    duration: 3
+    visible: true
 }


### PR DESCRIPTION
When the user removes the extension from the title (willingly or not), 'undefined' appears as the file extension: http://take.ms/AjKTnu
Fixed version: http://take.ms/c7rpH