### PR TITLE
Removed Vue console warning about dev mode in prod env

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -18,6 +18,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 const devtool = process.env.NODE_ENV === 'production' ? 'source-map' : 'eval-source-map'
+const vuealias = process.env.NODE_ENV === 'production' ? 'vue/dist/vue.min.js' : 'vue/dist/vue.js'
 
 module.exports = {
   entry: './src/index.coffee',
@@ -64,7 +65,7 @@ module.exports = {
   plugins,
   resolve: {
     alias: {
-      vue: 'vue/dist/vue.js'
+      vue: vuealias
     },
     extensions: [ '.js', '.json', '.vue', '.coffee' ],
     modules: [ 'node_modules', path.resolve(__dirname, 'src') ]


### PR DESCRIPTION
Added a check that tells webpack which Vue version to use (minified version on `NODE_ENV=production`, normal version on everything else). The minified version gets rid of the warning in the console and the use of the Vue Devtools browser extension in production environment.

![Example of the warning](https://i.imgur.com/dcaPze6.png)

![Vue devtools](https://i.imgur.com/AnQsJnK.png)

I wasn't sure whether you wanted to do anything about this, but here's the PR anyway, you can do whatever you want with it 😃 